### PR TITLE
feat: 支持传入bitmap和image的二进制数据

### DIFF
--- a/include/OcrLite.h
+++ b/include/OcrLite.h
@@ -35,6 +35,11 @@ public:
                      int padding, int maxSideLen,
                      float boxScoreThresh, float boxThresh, float unClipRatio, bool doAngle, bool mostAngle);
 
+    OcrResult detectImageBytes(const uint8_t *data, long dataLength, int grey, int padding, int maxSideLen,
+                               float boxScoreThresh, float boxThresh, float unClipRatio, bool doAngle, bool mostAngle);
+    OcrResult detectBitmap(uint8_t *bitmapData, int width, int height,int channels, int padding, int maxSideLen,
+                           float boxScoreThresh, float boxThresh, float unClipRatio, bool doAngle, bool mostAngle);
+
 private:
     bool isOutputConsole = false;
     bool isOutputPartImg = false;

--- a/include/OcrLiteCApi.h
+++ b/include/OcrLiteCApi.h
@@ -1,6 +1,7 @@
 #ifdef __cplusplus
 #ifndef __OCR_LITE_C_API_H__
 #define __OCR_LITE_C_API_H__
+#include "stdint.h"
 extern "C"
 {
 
@@ -32,6 +33,38 @@ typedef struct __ocr_param {
     int doAngle; // 1 means do
     int mostAngle; // 1 means true
 } OCR_PARAM;
+typedef struct {
+    double x;
+    double y;
+} OCR_POINT;
+typedef struct {
+    uint8_t *data;
+    int type;
+    int channels;
+    int width;
+    int height;
+    long dataLength;
+} OCR_INPUT;
+typedef struct {
+    OCR_POINT* boxPoint;
+    float boxScore;
+    int angleIndex;
+    float angleScore;
+    double angleTime;
+    uint8_t *text;
+    float *charScores;
+    unsigned long long charScoresLength;
+    unsigned long long boxPointLength;
+    unsigned long long textLength;
+    double crnnTime;
+    double blockTime;
+} TEXT_BLOCK;
+typedef struct {
+    double dbNetTime;
+    TEXT_BLOCK *textBlocks;
+    unsigned long long textBlocksLength;
+    double detectTime;
+} OCR_RESULT;
 
 /*
 By default, nThreads should be the number of threads
@@ -41,6 +74,9 @@ OcrInit(const char *szDetModel, const char *szClsModel, const char *szRecModel, 
 
 _QM_OCR_API OCR_BOOL
 OcrDetect(OCR_HANDLE handle, const char *imgPath, const char *imgName, OCR_PARAM *pParam);
+
+_QM_OCR_API OCR_BOOL
+OcrDetectInput(OCR_HANDLE handle, OCR_INPUT *input, OCR_PARAM *pParam, OCR_RESULT *ocrResult);
 
 _QM_OCR_API int OcrGetLen(OCR_HANDLE handle);
 

--- a/src/OcrLite.cpp
+++ b/src/OcrLite.cpp
@@ -75,7 +75,6 @@ OcrResult OcrLite::detect(const char *path, const char *imgName,
                           const int padding, const int maxSideLen,
                           float boxScoreThresh, float boxThresh, float unClipRatio, bool doAngle, bool mostAngle) {
     std::string imgFile = getSrcImgFilePath(path, imgName);
-
     cv::Mat originSrc = imread(imgFile, cv::IMREAD_COLOR);//default : BGR
     int originMaxSide = (std::max)(originSrc.cols, originSrc.rows);
     int resize;
@@ -93,6 +92,37 @@ OcrResult OcrLite::detect(const char *path, const char *imgName,
                     boxScoreThresh, boxThresh, unClipRatio, doAngle, mostAngle);
     return result;
 }
+
+
+OcrResult OcrLite::detectImageBytes(const uint8_t *data, const long dataLength, const int grey,
+                                    const int padding, const int maxSideLen,
+                                    float boxScoreThresh, float boxThresh, float unClipRatio, bool doAngle,
+                                    bool mostAngle) {
+    std::vector<uint8_t> vecData(data, data + dataLength);
+    cv::Mat originSrc = cv::imdecode(vecData, grey == 1 ? cv::IMREAD_GRAYSCALE : cv::IMREAD_COLOR);//default : BGR
+    OcrResult result;
+    result = detect(originSrc, padding, maxSideLen,
+                    boxScoreThresh, boxThresh, unClipRatio, doAngle, mostAngle);
+    return result;
+
+}
+
+OcrResult OcrLite::detectBitmap(uint8_t *bitmapData, int width, int height, int channels, int padding,
+                                int maxSideLen, float boxScoreThresh, float boxThresh, float unClipRatio, bool doAngle,
+                                bool mostAngle) {
+
+    auto *originSrc = new cv::Mat(height, width, CV_8UC(channels), bitmapData);
+    if (channels > 3) {
+        cv::cvtColor(*originSrc, *originSrc, cv::COLOR_RGBA2BGR);
+    } else if (channels == 3) {
+        cv::cvtColor(*originSrc, *originSrc, cv::COLOR_RGB2BGR);
+    }
+    OcrResult result;
+    result = detect(*originSrc, padding, maxSideLen,
+                    boxScoreThresh, boxThresh, unClipRatio, doAngle, mostAngle);
+    return result;
+}
+
 
 OcrResult OcrLite::detect(const cv::Mat &mat, int padding, int maxSideLen, float boxScoreThresh, float boxThresh,
                           float unClipRatio, bool doAngle, bool mostAngle) {

--- a/src/OcrLiteCApi.cpp
+++ b/src/OcrLiteCApi.cpp
@@ -65,6 +65,93 @@ OcrDetect(OCR_HANDLE handle, const char *imgPath, const char *imgName, OCR_PARAM
         return FALSE;
 }
 
+_QM_OCR_API OCR_BOOL
+OcrDetectInput(OCR_HANDLE handle, OCR_INPUT *input, OCR_PARAM *pParam, OCR_RESULT *ocrResult) {
+
+    OCR_OBJ *pOcrObj = (OCR_OBJ *) handle;
+    if (!pOcrObj)
+        return FALSE;
+
+    OCR_PARAM Param = *pParam;
+    if (Param.padding == 0)
+        Param.padding = 50;
+
+    if (Param.maxSideLen == 0)
+        Param.maxSideLen = 1024;
+
+    if (Param.boxScoreThresh == 0)
+        Param.boxScoreThresh = 0.6;
+
+    if (Param.boxThresh == 0)
+        Param.boxThresh = 0.3f;
+
+    if (Param.unClipRatio == 0)
+        Param.unClipRatio = 2.0;
+
+    if (Param.doAngle == 0)
+        Param.doAngle = 1;
+
+    if (Param.mostAngle == 0)
+        Param.mostAngle = 1;
+    OcrResult result;
+    if(input->dataLength == 0) {
+        return FALSE;
+    }
+
+    if(input->type == 0){
+        if(input->channels == 0){
+            return FALSE;
+        }
+        result = pOcrObj->OcrObj.detectBitmap(input->data,input->width,input->height, input->channels, Param.padding, Param.maxSideLen,
+                                                        Param.boxScoreThresh, Param.boxThresh, Param.unClipRatio,
+                                                        Param.doAngle != 0, Param.mostAngle != 0);
+    }
+
+    if(input->type == 1){
+        result= pOcrObj->OcrObj.detectImageBytes(input->data,input->dataLength, input->channels >= 3 ? 0 : 1, Param.padding, Param.maxSideLen,
+                                                 Param.boxScoreThresh, Param.boxThresh, Param.unClipRatio,
+                                                 Param.doAngle != 0, Param.mostAngle != 0);
+    }
+
+    if (result.strRes.length() > 0) {
+        ocrResult->dbNetTime = result.dbNetTime;
+        ocrResult->detectTime = result.detectTime;
+        ocrResult->textBlocksLength = result.textBlocks.size();
+        // 计算所需内存大小
+        size_t count = result.textBlocks.size();
+
+       // 分配足够大的内存块
+        auto *rawArray = static_cast<TEXT_BLOCK*>(calloc(count, sizeof(TEXT_BLOCK)));
+        for (size_t i = 0; i < count; i++) {
+            TextBlock textBlock = result.textBlocks[i];
+
+            rawArray[i].boxScore = textBlock.boxScore;
+            rawArray[i].angleIndex = textBlock.angleIndex;
+            rawArray[i].angleScore = textBlock.angleScore;
+            rawArray[i].angleTime = textBlock.angleTime;
+            auto* charScore = static_cast<float*>(calloc(textBlock.charScores.size(), sizeof(float)));
+            std::copy(textBlock.charScores.begin(), textBlock.charScores.end(), charScore);
+            rawArray[i].charScores = charScore;
+            rawArray[i].charScoresLength = textBlock.charScores.size();
+            auto * boxPoint= static_cast<OCR_POINT*>(calloc(textBlock.boxPoint.size(), sizeof (OCR_POINT)));
+            for(size_t boxPointIdx = 0; boxPointIdx < textBlock.boxPoint.size(); boxPointIdx++){
+                boxPoint[boxPointIdx].x = textBlock.boxPoint[boxPointIdx].x;
+                boxPoint[boxPointIdx].y = textBlock.boxPoint[boxPointIdx].y;
+            }
+            rawArray[i].boxPoint = boxPoint;
+            rawArray[i].boxPointLength = textBlock.boxPoint.size();
+            auto* text = static_cast<uint8_t*>(calloc(textBlock.text.size(), sizeof (uint8_t)));
+            std::copy(textBlock.text.begin(), textBlock.text.end(), text);
+            rawArray[i].text = text;
+            rawArray[i].textLength = textBlock.text.size() + 1;
+            rawArray[i].crnnTime = textBlock.crnnTime;
+            rawArray[i].blockTime = textBlock.blockTime;
+        }
+        ocrResult->textBlocks = rawArray;
+        return TRUE;
+    } else
+        return FALSE;
+}
 
 _QM_OCR_API int OcrGetLen(OCR_HANDLE handle) {
     OCR_OBJ *pOcrObj = (OCR_OBJ *) handle;


### PR DESCRIPTION
已使用jni方式，在macos-arm64和windows-x86_64经过测试，测试代码[windows-x86_64](https://github.com/MyMonsterCat/RapidOcr-Java/commit/3d1b2498c4002e8d1f18492ee72a87fb42df8007)