### PR TITLE
Enhance ONNX Runtime GPU inference performance

### DIFF
--- a/src/AngleNet.cpp
+++ b/src/AngleNet.cpp
@@ -8,8 +8,8 @@ void AngleNet::setGpuIndex(int gpuIndex) {
         OrtCUDAProviderOptions cuda_options;
         cuda_options.device_id = gpuIndex;
         cuda_options.arena_extend_strategy = 0;
-        cuda_options.gpu_mem_limit = 2 * 1024 * 1024 * 1024;
-        cuda_options.cudnn_conv_algo_search = OrtCudnnConvAlgoSearch::OrtCudnnConvAlgoSearchExhaustive;
+        cuda_options.gpu_mem_limit = 2ULL * 1024 * 1024 * 1024;
+        cuda_options.cudnn_conv_algo_search = OrtCudnnConvAlgoSearchDefault;
         cuda_options.do_copy_in_default_stream = 1;
 
         sessionOptions.AppendExecutionProvider_CUDA(cuda_options);

--- a/src/CrnnNet.cpp
+++ b/src/CrnnNet.cpp
@@ -9,8 +9,8 @@ void CrnnNet::setGpuIndex(int gpuIndex) {
         OrtCUDAProviderOptions cuda_options;
         cuda_options.device_id = gpuIndex;
         cuda_options.arena_extend_strategy = 0;
-        cuda_options.gpu_mem_limit = 2 * 1024 * 1024 * 1024;
-        cuda_options.cudnn_conv_algo_search = OrtCudnnConvAlgoSearch::OrtCudnnConvAlgoSearchExhaustive;
+        cuda_options.gpu_mem_limit = 2ULL * 1024 * 1024 * 1024;
+        cuda_options.cudnn_conv_algo_search = OrtCudnnConvAlgoSearchDefault;
         cuda_options.do_copy_in_default_stream = 1;
 
         sessionOptions.AppendExecutionProvider_CUDA(cuda_options);

--- a/src/DbNet.cpp
+++ b/src/DbNet.cpp
@@ -7,8 +7,8 @@ void DbNet::setGpuIndex(int gpuIndex) {
         OrtCUDAProviderOptions cuda_options;
         cuda_options.device_id = gpuIndex;
         cuda_options.arena_extend_strategy = 0;
-        cuda_options.gpu_mem_limit = 2 * 1024 * 1024 * 1024;
-        cuda_options.cudnn_conv_algo_search = OrtCudnnConvAlgoSearch::OrtCudnnConvAlgoSearchExhaustive;
+        cuda_options.gpu_mem_limit = 2ULL * 1024 * 1024 * 1024;
+        cuda_options.cudnn_conv_algo_search = OrtCudnnConvAlgoSearchDefault;
         cuda_options.do_copy_in_default_stream = 1;
 
         sessionOptions.AppendExecutionProvider_CUDA(cuda_options);


### PR DESCRIPTION
After referring to the approach suggested in [PaddleOCR#13154](https://github.com/PaddlePaddle/PaddleOCR/pull/13154), empirical tests confirmed that modifying the configuration of the convolution search algorithm significantly enhances the inference speed, achieving a tenfold increase. This improvement is the contribution of my work in this PR.