### PR TITLE
Add OcrLiteCApi memory free function; users can free text blocks' memory themselves

### DIFF
--- a/include/OcrLite.h
+++ b/include/OcrLite.h
@@ -49,7 +49,7 @@ private:
     DbNet dbNet;
     AngleNet angleNet;
     CrnnNet crnnNet;
-
+    char *loggerBuffer;
     std::vector<cv::Mat> getPartImages(cv::Mat &src, std::vector<TextBox> &textBoxes,
                                        const char *path, const char *imgName);
 

--- a/include/OcrLiteCApi.h
+++ b/include/OcrLiteCApi.h
@@ -78,6 +78,9 @@ OcrDetect(OCR_HANDLE handle, const char *imgPath, const char *imgName, OCR_PARAM
 _QM_OCR_API OCR_BOOL
 OcrDetectInput(OCR_HANDLE handle, OCR_INPUT *input, OCR_PARAM *pParam, OCR_RESULT *ocrResult);
 
+_QM_OCR_API OCR_BOOL
+OcrFreeResult(OCR_RESULT *result);
+
 _QM_OCR_API int OcrGetLen(OCR_HANDLE handle);
 
 _QM_OCR_API OCR_BOOL OcrGetResult(OCR_HANDLE handle, char *szBuf, int nLen);

--- a/src/OcrLite.cpp
+++ b/src/OcrLite.cpp
@@ -110,15 +110,14 @@ OcrResult OcrLite::detectImageBytes(const uint8_t *data, const long dataLength, 
 OcrResult OcrLite::detectBitmap(uint8_t *bitmapData, int width, int height, int channels, int padding,
                                 int maxSideLen, float boxScoreThresh, float boxThresh, float unClipRatio, bool doAngle,
                                 bool mostAngle) {
-
-    auto *originSrc = new cv::Mat(height, width, CV_8UC(channels), bitmapData);
+    cv::Mat originSrc(height, width, CV_8UC(channels), bitmapData);
     if (channels > 3) {
-        cv::cvtColor(*originSrc, *originSrc, cv::COLOR_RGBA2BGR);
+        cv::cvtColor(originSrc, originSrc, cv::COLOR_RGBA2BGR);
     } else if (channels == 3) {
-        cv::cvtColor(*originSrc, *originSrc, cv::COLOR_RGB2BGR);
+        cv::cvtColor(originSrc, originSrc, cv::COLOR_RGB2BGR);
     }
     OcrResult result;
-    result = detect(*originSrc, padding, maxSideLen,
+    result = detect(originSrc, padding, maxSideLen,
                     boxScoreThresh, boxThresh, unClipRatio, doAngle, mostAngle);
     return result;
 }

--- a/src/OcrLite.cpp
+++ b/src/OcrLite.cpp
@@ -2,12 +2,15 @@
 #include "OcrUtils.h"
 #include <stdarg.h> //windows&linux
 
-OcrLite::OcrLite() {}
+OcrLite::OcrLite() {
+    loggerBuffer = (char *)malloc(8192);
+}
 
 OcrLite::~OcrLite() {
     if (isOutputResultTxt) {
         fclose(resultTxt);
     }
+    free(loggerBuffer);
 }
 
 void OcrLite::setNumThread(int numOfThread) {
@@ -53,14 +56,13 @@ bool OcrLite::initModels(const std::string &detPath, const std::string &clsPath,
 
 void OcrLite::Logger(const char *format, ...) {
     if (!(isOutputConsole || isOutputResultTxt)) return;
-    char *buffer = (char *) malloc(8192);
+    memset(loggerBuffer, 0, 8192);
     va_list args;
     va_start(args, format);
-    vsprintf(buffer, format, args);
+    vsprintf(loggerBuffer, format, args);
     va_end(args);
-    if (isOutputConsole) printf("%s", buffer);
-    if (isOutputResultTxt) fprintf(resultTxt, "%s", buffer);
-    free(buffer);
+    if (isOutputConsole) printf("%s", loggerBuffer);
+    if (isOutputResultTxt) fprintf(resultTxt, "%s", loggerBuffer);
 }
 
 cv::Mat makePadding(cv::Mat &src, const int padding) {

--- a/src/OcrLiteCApi.cpp
+++ b/src/OcrLiteCApi.cpp
@@ -153,6 +153,20 @@ OcrDetectInput(OCR_HANDLE handle, OCR_INPUT *input, OCR_PARAM *pParam, OCR_RESUL
         return FALSE;
 }
 
+_QM_OCR_API OCR_BOOL
+OcrFreeResult(OCR_RESULT *result) {
+    if(result && result->textBlocksLength && result->textBlocks){
+        for(int i = 0; i < result->textBlocksLength; i++){
+            free(result->textBlocks[i].charScores);
+            free(result->textBlocks[i].text);
+            free(result->textBlocks[i].boxPoint);
+        }
+        free(result->textBlocks);
+        return true;
+    }
+    return false;
+}
+
 _QM_OCR_API int OcrGetLen(OCR_HANDLE handle) {
     OCR_OBJ *pOcrObj = (OCR_OBJ *) handle;
     if (!pOcrObj)


### PR DESCRIPTION
The new API empowers users to manage their memory allocation directly, allowing them to release memory at their discretion. This is especially important in scenarios where the OCR results may be processed multiple times or in batches.